### PR TITLE
Gu UI 3707 login should not show splash screen after redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,15 @@
                         </a>
                     </div>
 
-                    <terra-login id="login" button-label="Login" class="ml-3">
+                    <terra-button
+                        id="login-proxy"
+                        variant="primary"
+                        onclick=""
+                    >
+                        Login
+                    </terra-button>
+
+                    <terra-login id="login" button-label="Login" class="ml-3" style="display:none">
                         <div slot="logged-in" id="logout">
                             <!-- empty container that will be populated with the logout button -->
                         </div>
@@ -502,7 +510,7 @@
                 if (!helpBtn.contains(e.target) && !helpMenu.contains(e.target)) {
                     helpMenu.classList.add('hidden')
                 }
-            })
+            }) 
         </script>
         <script>
             document.addEventListener("DOMContentLoaded", function () {

--- a/src/components/login.ts
+++ b/src/components/login.ts
@@ -11,6 +11,7 @@ export class LoginComponent {
     #logoutSection: HTMLDivElement
 
     constructor() {
+        console.log('DEBUG: ********* LoginComponent ************ #constructor called')
         this.#loginEl = document.querySelector<TerraLogin>('#login')!
         this.#logoutSection = this.#loginEl.querySelector<HTMLDivElement>('#logout')!
 
@@ -20,11 +21,14 @@ export class LoginComponent {
 
     #bindEvents() {
         this.#loginEl.addEventListener('terra-login', (e: TerraLoginEvent) => {
+            console.log('DEBUG: ********* LoginComponent ************ terra-login event called')
             userState.value = {
                 ...userState.value,
                 user: e.detail.user?.uid ? (e.detail.user as User) : null,
                 userChecked: true,
             }
+            
+            console.log('DEBUG: user state updated:', userState.value)
         })
     }
 
@@ -58,6 +62,8 @@ export class LoginComponent {
 
                     // use token based logout
                     this.#loginEl.logout()
+
+                    sessionStorage.removeItem('earthdataAuthRedirect')
 
                     // also logout of URS
                     window.location.href = logoutUrl

--- a/src/components/login.ts
+++ b/src/components/login.ts
@@ -11,7 +11,6 @@ export class LoginComponent {
     #logoutSection: HTMLDivElement
 
     constructor() {
-        console.log('DEBUG: ********* LoginComponent ************ #constructor called')
         this.#loginEl = document.querySelector<TerraLogin>('#login')!
         this.#logoutSection = this.#loginEl.querySelector<HTMLDivElement>('#logout')!
 
@@ -21,14 +20,11 @@ export class LoginComponent {
 
     #bindEvents() {
         this.#loginEl.addEventListener('terra-login', (e: TerraLoginEvent) => {
-            console.log('DEBUG: ********* LoginComponent ************ terra-login event called')
             userState.value = {
                 ...userState.value,
                 user: e.detail.user?.uid ? (e.detail.user as User) : null,
-                userChecked: true,
+                userChecked: !e.detail.isLoading, // becomes true when auth finishes
             }
-            
-            console.log('DEBUG: user state updated:', userState.value)
         })
     }
 
@@ -63,7 +59,7 @@ export class LoginComponent {
                     // use token based logout
                     this.#loginEl.logout()
 
-                    sessionStorage.removeItem('earthdataAuthRedirect')
+                    localStorage.removeItem('loginInitiated')
 
                     // also logout of URS
                     window.location.href = logoutUrl

--- a/src/components/welcome-splash.ts
+++ b/src/components/welcome-splash.ts
@@ -1,6 +1,6 @@
-import { userState } from '../state'
-import { TerraLoginEvent } from '@nasa-terra/components'
 export class WelcomeSplashComponent {
+    #proxyLogin: HTMLElement
+    #login: HTMLElement
     #welcomeScreen: HTMLElement
     #skipBtn: HTMLElement
     #hideCheckbox: HTMLInputElement
@@ -10,53 +10,44 @@ export class WelcomeSplashComponent {
 
     constructor() {
         this.#welcomeScreen = document.getElementById('welcomeScreen')!
+        this.#proxyLogin = document.getElementById('login-proxy')!
+        this.#login = document.getElementById('login')!
         this.#skipBtn = document.getElementById('welcomeSkip')!
         this.#hideCheckbox = document.getElementById('hideWelcome') as HTMLInputElement
         this.#createMapWidget = document.getElementById('widget-create-map')
         this.#createTimeseriesWidget = document.getElementById('widget-create-timeseries')
         this.#userGuideWidget = document.getElementById('widget-user-guide')
 
+        this.#setupEventListeners()  
         this.#initialize()
     }
 
     #initialize() {
         this.#welcomeScreen.style.display = 'none'  // Default to hidden
         
-        console.log('DEBUG: ********* WelcomeSplashComponent ************ #initialize called')
-        
-        // Check if user opted out of welcome screenpreviously
         const hide = localStorage.getItem('hideWelcomeScreen') === 'true'
+        const redirectFromLogin = localStorage.getItem('loginInitiated') === 'true'
 
-        if (hide) {
+        // If authentication is in progress, don't show welcome screen.
+        if (redirectFromLogin) {
+            this.#login.style.display = 'inline-flex'  // unhide actual login component
+            this.#proxyLogin.style.display = 'none'  // hide the proxy login button
+            localStorage.removeItem('loginInitiated')
             return
         }
 
-        console.log('DEBUG: welcomeScreen.style.disply:', this.#welcomeScreen.style.display)
-        console.log('DEBUG: hideWelcomeScreen:', hide)
-        console.log('DEBUG: userState in WelcomeSplashComponent #initialize:', userState.value)
-
-        this.#setupEventListeners()
-
-        // 🚨 IMPORTANT: defer decision until auth state settles
-        // Determine whether to show welcome screen based on user login status
-        queueMicrotask(() => {
-            this.#evaluateVisibility()
-        })
+        this.#welcomeScreen.style.display = hide ? 'none' : 'flex'
     }
 
     #setupEventListeners() {
 
-        // Setup listener for login event
-        window.addEventListener('terra-login', (e: TerraLoginEvent) => {
-            const isLoggedIn = !!e.detail?.user?.uid
+        this.#proxyLogin.addEventListener('click', () => {
+            localStorage.setItem('loginInitiated', 'true')  // Set flag to indicate login initiated
 
-            console.log('DEBUG: terra-login event → isLoggedIn:', isLoggedIn)
-
-            if (isLoggedIn) {
-                this.#closeSplash()
-            } else {
-                this.#welcomeScreen.style.display = 'flex'
-            }
+            const internalLoginBtn = this.#login.shadowRoot?.querySelector('terra-button')
+            internalLoginBtn?.click()
+            this.#login.style.display = 'inline-flex'   // unhide actual login component
+            this.#proxyLogin.style.display = 'none'     // hide the proxy login button 
         })
 
         this.#skipBtn.addEventListener('click', () => this.#closeSplash())
@@ -81,20 +72,7 @@ export class WelcomeSplashComponent {
         })
     }
 
-    #evaluateVisibility() {
-        const isLoggedIn = !!userState.value.user
-
-        console.log('DEBUG: evaluateVisibility → isLoggedIn:', isLoggedIn)
-
-        if (isLoggedIn) {
-            this.#closeSplash()
-        } else {
-            this.#welcomeScreen.style.display = 'flex'
-        }
-    }
-
     #closeSplash() {
-        console.log('DEBUG: ********* WelcomeSplashComponent ************ #closeSplash called')
         if (this.#hideCheckbox.checked) {
             localStorage.setItem('hideWelcomeScreen', 'true')   // Save user preference to hide welcome screen
         }

--- a/src/components/welcome-splash.ts
+++ b/src/components/welcome-splash.ts
@@ -1,3 +1,5 @@
+import { userState } from '../state'
+import { TerraLoginEvent } from '@nasa-terra/components'
 export class WelcomeSplashComponent {
     #welcomeScreen: HTMLElement
     #skipBtn: HTMLElement
@@ -18,15 +20,45 @@ export class WelcomeSplashComponent {
     }
 
     #initialize() {
-        // Check if user opted out previously
-        const hide = localStorage.getItem('hideWelcomeScreen')
+        this.#welcomeScreen.style.display = 'none'  // Default to hidden
+        
+        console.log('DEBUG: ********* WelcomeSplashComponent ************ #initialize called')
+        
+        // Check if user opted out of welcome screenpreviously
+        const hide = localStorage.getItem('hideWelcomeScreen') === 'true'
 
-        this.#welcomeScreen.style.display = hide === 'true' ? 'none' : 'flex'
+        if (hide) {
+            return
+        }
+
+        console.log('DEBUG: welcomeScreen.style.disply:', this.#welcomeScreen.style.display)
+        console.log('DEBUG: hideWelcomeScreen:', hide)
+        console.log('DEBUG: userState in WelcomeSplashComponent #initialize:', userState.value)
 
         this.#setupEventListeners()
+
+        // 🚨 IMPORTANT: defer decision until auth state settles
+        // Determine whether to show welcome screen based on user login status
+        queueMicrotask(() => {
+            this.#evaluateVisibility()
+        })
     }
 
     #setupEventListeners() {
+
+        // Setup listener for login event
+        window.addEventListener('terra-login', (e: TerraLoginEvent) => {
+            const isLoggedIn = !!e.detail?.user?.uid
+
+            console.log('DEBUG: terra-login event → isLoggedIn:', isLoggedIn)
+
+            if (isLoggedIn) {
+                this.#closeSplash()
+            } else {
+                this.#welcomeScreen.style.display = 'flex'
+            }
+        })
+
         this.#skipBtn.addEventListener('click', () => this.#closeSplash())
 
         // Create Map Widget
@@ -49,9 +81,22 @@ export class WelcomeSplashComponent {
         })
     }
 
+    #evaluateVisibility() {
+        const isLoggedIn = !!userState.value.user
+
+        console.log('DEBUG: evaluateVisibility → isLoggedIn:', isLoggedIn)
+
+        if (isLoggedIn) {
+            this.#closeSplash()
+        } else {
+            this.#welcomeScreen.style.display = 'flex'
+        }
+    }
+
     #closeSplash() {
+        console.log('DEBUG: ********* WelcomeSplashComponent ************ #closeSplash called')
         if (this.#hideCheckbox.checked) {
-            localStorage.setItem('hideWelcomeScreen', 'true')
+            localStorage.setItem('hideWelcomeScreen', 'true')   // Save user preference to hide welcome screen
         }
         this.#welcomeScreen.style.display = 'none'
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,9 +20,9 @@ localStorage.setItem('terra-environment', 'prod')
 
 document.addEventListener('DOMContentLoaded', () => {
     new UrlsParamsComponent()
-    new WelcomeSplashComponent()
     new LoginComponent()
     new LoginModalComponent()
+    new WelcomeSplashComponent()
     new AddVariableDialogComponent()
     new PlotTypeSelectorComponent()
     new SelectVariablesComponent()


### PR DESCRIPTION
This fix improves the Welcome Splash UI flow. If a user is unauthenticated and loads the Giovanni app they are presented with the Welcome splash screen. After they dismiss the splash screen and then click the login button to authenticate, the Welcome splash will not reappear when the app reloads. 

I tried several ways to accomplish this using the userState as well as the token in sessionStorage to determine if the user is authenticated, but the issue was that the welcome-splash initialize function (which controls the display of the splash screen) executes before the terra-login component wraps up authentication and populates the userState and token in sessionStorage.  

The solution was to create a proxy-login button with a click event that sets a localStorage item called loginInitiated. When the app refreshes if loginInitiated is set then the welcome splash is not displayed. 